### PR TITLE
[plugin.video.thinktv] 3.0.15

### DIFF
--- a/plugin.video.thinktv/README.txt
+++ b/plugin.video.thinktv/README.txt
@@ -4,6 +4,7 @@ plugin.video.thinktv
 Kodi Video Addon for PBS ThinkTV
 For Kodi Krypton and above releases
 
+version 3.0.15 fix for website change, bugfix for 3.0.14 update
 version 3.0.14 fix getvideo for new api
 version 3.0.13 fix movies/specials to be able to play
 version 3.0.12 try to handle multiple seasons

--- a/plugin.video.thinktv/addon.xml
+++ b/plugin.video.thinktv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.thinktv"
        name="PBS ThinkTV"
-       version="3.0.14"
+       version="3.0.15"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>

--- a/plugin.video.thinktv/changelog.txt
+++ b/plugin.video.thinktv/changelog.txt
@@ -1,3 +1,4 @@
+version 3.0.15 fix for website change, bugfix for 3.0.14 update
 version 3.0.14 fix getvideo for new api
 version 3.0.13 fix movies/specials to be able to play
 version 3.0.12 try to handle multiple seasons

--- a/plugin.video.thinktv/resources/lib/scraper.py
+++ b/plugin.video.thinktv/resources/lib/scraper.py
@@ -228,7 +228,7 @@ class myAddon(t1mAddon):
     epis = re.compile('<article class="video-summary">.+?data-srcset="(.+?)".+?alt="(.+?)".+?class="description">(.+?)<.+?data-video-slug="(.+?)"',re.DOTALL).findall(html)
     if len(epis) == 0:
 #        epis = re.compile('<div class="video-summary">.+?data-srcset="(.+?)".+?alt="(.+?)".+?class="description">(.+?)<.+?data-video-id="(.+?)"',re.DOTALL).findall(html)
-        epis = re.compile('<div class="video-summary">.+?data-srcset="(.+?)".+?alt="(.+?)".+?class="description">(.+?)<.+?data-video-slug="(.+?)"',re.DOTALL).findall(html)
+        epis = re.compile('<div class="video-summary"[^>]+>.+?data-srcset="(.+?)".+?alt="(.+?)".+?class="description">(.+?)<.+?data-video-slug="(.+?)"',re.DOTALL).findall(html)
     for i, (imgs, name, plot, url)  in list(enumerate(epis, start=1)):
         name = h.unescape(name.decode(UTF8))
         name = name.replace('Video thumbnail: ','',1)
@@ -311,7 +311,7 @@ class myAddon(t1mAddon):
     addonLanguage = self.addon.getLocalizedString
     pbs_uid = self.addon.getSetting('pbs_uid')
     pg = self.getRequest('https://player.pbs.org/viralplayer/%s/?uid=%s' % (url, pbs_uid))
-    pg = re.compile('window.videoBridge = (.+?);').search(pg).group(1)
+    pg = re.compile('window.videoBridge = (.+);').search(pg).group(1)
     a = json.loads(pg)
     if not a is None:
         url = a['recommended_encoding']['url']


### PR DESCRIPTION
### Description
- Small change to the website format
- Fix for bug introduced in 3.0.14 where if any part of the JSON blob has a semi-colon in it, the RE match stops matching that that semi-colon instead of the semi-colon at the end of the blob
  - remove the non-greedy modifier

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0